### PR TITLE
Adding guard to header file to allow include in multiple files

### DIFF
--- a/src/EasyStringStream.h
+++ b/src/EasyStringStream.h
@@ -1,3 +1,6 @@
+#ifndef EASY_STRING_STREAM_GUARD_H
+#define EASY_STRING_STREAM_GUARD_H
+
 #include <stdint.h>
 #include <math.h>
 
@@ -58,3 +61,4 @@ public:
 #endif
 };
 
+#endif


### PR DESCRIPTION
Adds a guard to the header file to allow for include into multiple files in the same executable.