### PR TITLE
Allow inheritance of methods that want to skip the buffer update

### DIFF
--- a/src/EasyStringStream.h
+++ b/src/EasyStringStream.h
@@ -26,9 +26,9 @@ public:
 	const char* get();
 	int getCursor();
 	int getLength();
-	size_t print(const char[]);
-	size_t print(char);
-	size_t print(unsigned char);
+	size_t virtual print(const char[]);
+	size_t virtual print(char);
+	size_t virtual print(unsigned char);
 	size_t print(int, int = -1);
 	size_t print(unsigned int, int = -1);
 	size_t print(long, int = -1);


### PR DESCRIPTION
Allows for overriding the buffer update methods in a subclass.  Specifically, this is useful because i wanted to create an interface that was the same as EasyString, but instead of the buffer update, i wanted to do Serial.print.